### PR TITLE
WAZO-4158-fix-file-descriptors-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ INSERT INTO services_by_serveur VALUES (default, 9, 10);  # where 9 is the serve
 ## Logs
 
 * Load-monitor logs are written to `/var/log/apache2/error.log`
+
+## Configure plugins
+
+Plugins can be configured to run as a specific user:
+
+- `xivo_asterisk_file_descriptors` needs to run as root
+
+  ```shell
+  cat > /etc/munin/plugin-conf/load-monitor <<-EOF
+  [xivo_asterisk_file_descriptors]
+  user root
+  EOF
+  ```

--- a/load-monitor/munin-plugins/xivo_asterisk_file_descriptors
+++ b/load-monitor/munin-plugins/xivo_asterisk_file_descriptors
@@ -1,20 +1,6 @@
-#!/bin/bash
-
-# Copyright (C) 2012  Avencall
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>
-
+#!/usr/bin/env bash
+# Copyright 2012-2025 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 case $1 in
     config)
@@ -28,6 +14,5 @@ EOM
         exit 0;;
 esac
 
-echo -n "asteriskfiledesc.value "; /usr/bin/lsof | grep -c asterisk
-
+echo -n "asteriskfiledesc.value "; ls -d /proc/$(pidof asterisk)/fd/* 2>/dev/null | wc -l
 exit 0


### PR DESCRIPTION
why:
- it’s executed by user that doesn’t access to the lsof output
- previous command counted more than file descriptors (socket, etc..)
